### PR TITLE
tempArea dictionary of docks is recreated on program start

### DIFF
--- a/pyqtgraph/dockarea/DockArea.py
+++ b/pyqtgraph/dockarea/DockArea.py
@@ -234,6 +234,8 @@ class DockArea(Container, QtGui.QWidget, DockDrop):
         ## 3) create floating areas, populate
         for s in state['float']:
             a = self.addTempArea()
+            for name, dock in docks.iteritems():
+                a.docks[name] = dock
             a.buildFromState(s[0]['main'], docks, a)
             a.win.setGeometry(*s[1])
         


### PR DESCRIPTION
This eliminates a very specific bug: If a plot window is popped out to be a stand alone window, the program is then closed, the program is reopened, and then the popped out plot window is closed, previously it would not be added back into the main window. This would result in an exception the next time the program was started.